### PR TITLE
Remove Mac and Linux tags from the WindowsDX template

### DIFF
--- a/CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
+++ b/CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
@@ -1,7 +1,7 @@
 {
     "author": "MonoGame Team",
     "classifications": [
-        "MonoGame", "Games", "Desktop", "Windows", "Linux", "macOS"
+        "MonoGame", "Games", "Desktop", "Windows"
     ],
     "name": "MonoGame Windows Desktop Application",
     "groupIdentity": "MonoGame.Application.WindowsDX",


### PR DESCRIPTION
The WindowsDX template does NOT support Mac or Linux