### PR TITLE
Fix dotnet tool restore from Visual Studio

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
@@ -24,7 +24,7 @@
       <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
@@ -25,7 +25,7 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
@@ -24,7 +24,7 @@
       <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
@@ -25,7 +25,7 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
     <Message Text="Restoring dotnet tools" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools" Importance="High" />
+    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
     <Exec Command="dotnet tool restore" />
   </Target>
 </Project>


### PR DESCRIPTION
```<Target Name="RestoreDotnetTools" BeforeTargets="Restore">``` never worked with Visual Studio, it only works when the .NET CLI is used.

This is because the target ```Restore``` is never called with Visual Studio. Visual Studio does a _solution-wide_ restore, but it doesn't do a per-project restore. While the .NET CLI only do per-project restore.

To "fix", the .NET team has surfaced a new target that can be used to do a similar task, but that works with both the .NET CLI and Visual Studio: ```CollectPackageReferences``` (for reference: https://github.com/NuGet/Home/issues/4634)

This PR also makes the restore message more elaborate by adding a notice about how long it may take and how often.