### PR TITLE
Cleanup restoredotnettools - no longer required

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
@@ -20,8 +20,4 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
@@ -24,8 +24,4 @@
       <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
@@ -11,8 +11,4 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -26,8 +26,4 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -15,8 +15,4 @@
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
@@ -9,8 +9,4 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -20,8 +20,4 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.DesktopGL/___SafeGameName___.DesktopGL.csproj
@@ -20,8 +20,4 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.WindowsDX/___SafeGameName___.WindowsDX.csproj
@@ -24,8 +24,4 @@
       <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.*" />
   </ItemGroup>
-  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
-    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
-    <Exec Command="dotnet tool restore" />
-  </Target>
 </Project>


### PR DESCRIPTION
# Summary

Following [Remove the RestoreContentCompiler as it was redundant.](https://github.com/MonoGame/MonoGame/pull/8815), the "<Targets" for managing `dotnet restore` and `dotnet tool restore` is no longer required.

This section should be removed from all templates for the 3.8.5 release and beyond

```xml
  <Target Name="RestoreDotnetTools" BeforeTargets="CollectPackageReferences">
    <Message Text="Restoring dotnet tools (this might take a while depending on your internet speed and should only happen upon building your project for the first time, or after upgrading MonoGame, or clearing your nuget cache)" Importance="High" />
    <Exec Command="dotnet tool restore" />
  </Target>
```

Resolves - #23 