### PR TITLE
Update builder templates to be no import defaults

### DIFF
--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/Builder/Builder.cs
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/Builder/Builder.cs
@@ -36,11 +36,28 @@ public class Builder : ContentBuilder
     {
         var contentCollection = new ContentCollection();
 
-        // include everything in the folder
-        contentCollection.Include<WildcardRule>("*");
+        // By default, no content will be imported from the Assets folder using the default importer for their file type.
+        // Please define your content collection rules here.
 
-        // By default, all content will be imported from the Assets folder using the default importer for their file type.
-        // Please add any custom content collection rules here.
+        /* Examples
+
+        // Import all content in the Assets folder using the default importer for their file type.
+        content.Include<WildcardRule>("*");
+
+        // Only copy content from the assets folder rather than build it with the pipeline.
+        content.IncludeCopy<WildcardRule>("*.json");
+
+        // Exclude assets that match the pattern., only required overriding a default import behaviour.
+        content.Exclude<WildcardRule>("Font/*.txt");
+
+        // Include a specific asset with processor parameters.
+        content.Include("Models/character.glb", new FbxImporter(),
+            new MeshAnimatedModelProcessor()
+            {
+                Scale = 100.0f
+            }
+        );
+        */
 
         return contentCollection;
     }

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/Builder/Builder.cs
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/Builder/Builder.cs
@@ -35,12 +35,29 @@ public class Builder : ContentBuilder
     public override IContentCollection GetContentCollection()
     {
         var contentCollection = new ContentCollection();
+6
+        // By default, no content will be imported from the Assets folder using the default importer for their file type.
+        // Please define your content collection rules here.
 
-        // include everything in the folder
-        contentCollection.Include<WildcardRule>("*");
+        /* Examples
 
-        // By default, all content will be imported from the Assets folder using the default importer for their file type.
-        // Please add any custom content collection rules here.
+        // Import all content in the Assets folder using the default importer for their file type.
+        content.Include<WildcardRule>("*");
+
+        // Only copy content from the assets folder rather than build it with the pipeline.
+        content.IncludeCopy<WildcardRule>("*.json");
+
+        // Exclude assets that match the pattern., only required overriding a default import behaviour.
+        content.Exclude<WildcardRule>("Font/*.txt");
+
+        // Include a specific asset with processor parameters.
+        content.Include("Models/character.glb", new FbxImporter(),
+            new MeshAnimatedModelProcessor()
+            {
+                Scale = 100.0f
+            }
+        );
+        */
 
         return contentCollection;
     }


### PR DESCRIPTION
# Summary

From discussions, the "catch all" rule by default introduces too many issues for new starters, as it breaks the existing pattern that the MGCB already imposes.

Only content you have configured should be imported.

Notes added to builder as a guide for building rules to supplement documentation.