### PR TITLE
Refactored the ContentBuilder targets file to also post-build package assets prior to compile

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -13,11 +13,6 @@
     <ProjectReference Include="..\___SafeGameName___.Core\___SafeGameName___.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidAsset Include="$(OutputPath)Content\**\*">
-      <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </AndroidAsset>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.5-preview.*" />
   </ItemGroup>
   <Import Project="..\___SafeGameName___.Content\BuildContent.targets" />

--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -3,10 +3,28 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o
+        $(ContentOutput) -i $(ContentTemp)</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
-   </Target>
+    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build"
+      RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Exec Command="$(ContentCommand) $(ContentArgs)"
+      WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+"
+      CustomWarningRegularExpression="\[W\] .+" />
+  </Target>
+  <Target Name="AddGeneratedContentAssets"
+    AfterTargets="BuildContent">
+    <ItemGroup>
+      <AndroidAsset Include="$(ProjectDir)$(OutputPath)Content\**\*"
+        Condition="'$(MonoGamePlatform)' == 'Android'">
+        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </AndroidAsset>
+
+      <BundledResource Include="$(ProjectDir)$(OutputPath)Content\**\*"
+        Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
+        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </BundledResource>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -10,11 +10,6 @@
     <ProjectReference Include="..\___SafeGameName___.Core\___SafeGameName___.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <BundleResource Include="$(OutputPath)Content\**\*">
-      <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </BundleResource>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.5-preview.*" />
   </ItemGroup>
   <Import Project="..\___SafeGameName___.Content\BuildContent.targets" />

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Android/___SafeGameName___.Android.csproj
@@ -13,11 +13,6 @@
     <ProjectReference Include="..\___SafeGameName___.Core\___SafeGameName___.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidAsset Include="$(OutputPath)Content\**\*">
-      <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </AndroidAsset>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.5-preview.*" />
   </ItemGroup>
   <Import Project="..\___SafeGameName___.Content\BuildContent.targets" />

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -3,10 +3,28 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o
+        $(ContentOutput) -i $(ContentTemp)</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
-   </Target>
+    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build"
+      RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Exec Command="$(ContentCommand) $(ContentArgs)"
+      WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+"
+      CustomWarningRegularExpression="\[W\] .+" />
+  </Target>
+  <Target Name="AddGeneratedContentAssets"
+    AfterTargets="BuildContent">
+    <ItemGroup>
+      <AndroidAsset Include="$(ProjectDir)$(OutputPath)Content\**\*"
+        Condition="'$(MonoGamePlatform)' == 'Android'">
+        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </AndroidAsset>
+
+      <BundledResource Include="$(ProjectDir)$(OutputPath)Content\**\*"
+        Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
+        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </BundledResource>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.iOS/___SafeGameName___.iOS.csproj
@@ -10,11 +10,6 @@
     <ProjectReference Include="..\___SafeGameName___.Core\___SafeGameName___.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <BundleResource Include="$(OutputPath)Content\**\*">
-      <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </BundleResource>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.5-preview.*" />
   </ItemGroup>
   <Import Project="..\___SafeGameName___.Content\BuildContent.targets" />

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
@@ -3,10 +3,28 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o
+        $(ContentOutput) -i $(ContentTemp)</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
-   </Target>
+    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build"
+      RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Exec Command="$(ContentCommand) $(ContentArgs)"
+      WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+"
+      CustomWarningRegularExpression="\[W\] .+" />
+  </Target>
+  <Target Name="AddGeneratedContentAssets"
+    AfterTargets="BuildContent">
+    <ItemGroup>
+      <AndroidAsset Include="$(ProjectDir)$(OutputPath)Content\**\*"
+        Condition="'$(MonoGamePlatform)' == 'Android'">
+        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </AndroidAsset>
+
+      <BundledResource Include="$(ProjectDir)$(OutputPath)Content\**\*"
+        Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
+        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </BundledResource>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
# Summary

Reworking the Content Builder to perform in a similar way to the original `MonoGame.Framework.Builder.Targets`, ensuring that the special content types are packaged in iOS/Android Builds.

New targets flow reads

* BeforeCompile -> BuildContent
* BuildContent -> AddGeneratedContentAssets
* AddGeneratedContentAssets -> Compile & package

This should ensure that the packaged assets are included in ANY iOS / Android build and are packaged for shipping.