### PR TITLE
Patch NuGet versions and update Android/IOS post-process

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -12,14 +12,16 @@
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">
     <ItemGroup>
-      <AndroidAsset Include="$(ProjectDir)$(OutputPath)Content\**\*"
+      <GeneratedAsset Include="$(ProjectDir)$(OutputPath)Content\**\*" />
+
+      <AndroidAsset Include="@(GeneratedAsset)"
         Condition="'$(MonoGamePlatform)' == 'Android'">
-        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Link>Content\%(GeneratedAsset.RecursiveDir)%(GeneratedAsset.Filename)%(GeneratedAsset.Extension)</Link>
       </AndroidAsset>
 
-      <BundledResource Include="$(ProjectDir)$(OutputPath)Content\**\*"
+      <BundledResource Include="@(GeneratedAsset)"
         Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
-        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Link>Content\%(GeneratedAsset.RecursiveDir)%(GeneratedAsset.Filename)%(GeneratedAsset.Extension)</Link>
       </BundledResource>
     </ItemGroup>
   </Target>

--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/___SafeGameName___.Content.csproj
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/___SafeGameName___.Content.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.5-preview.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.2" />
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
     <PackageReference Include="MonoGame.Library.MojoShader" Version="1.0.0.5" />
-    <PackageReference Include="MonoGame.Tool.Basisu" Version="1.60.0.3" />
-    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.5" />
-    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.10" />
-    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.9" />
-    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.9" />      
+    <PackageReference Include="MonoGame.Tool.Basisu" Version="2.0.2.1" />
+    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.7" />
+    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.11" />
+    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.10" />
+    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.10" />   
   </ItemGroup>
 </Project>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -12,14 +12,16 @@
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">
     <ItemGroup>
-      <AndroidAsset Include="$(ProjectDir)$(OutputPath)Content\**\*"
+      <GeneratedAsset Include="$(ProjectDir)$(OutputPath)Content\**\*" />
+
+      <AndroidAsset Include="@(GeneratedAsset)"
         Condition="'$(MonoGamePlatform)' == 'Android'">
-        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Link>Content\%(GeneratedAsset.RecursiveDir)%(GeneratedAsset.Filename)%(GeneratedAsset.Extension)</Link>
       </AndroidAsset>
 
-      <BundledResource Include="$(ProjectDir)$(OutputPath)Content\**\*"
+      <BundledResource Include="@(GeneratedAsset)"
         Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
-        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Link>Content\%(GeneratedAsset.RecursiveDir)%(GeneratedAsset.Filename)%(GeneratedAsset.Extension)</Link>
       </BundledResource>
     </ItemGroup>
   </Target>

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/___SafeGameName___.Content.csproj
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/___SafeGameName___.Content.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.5-preview.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.2" />
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
     <PackageReference Include="MonoGame.Library.MojoShader" Version="1.0.0.5" />
-    <PackageReference Include="MonoGame.Tool.Basisu" Version="1.60.0.3" />
-    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.5" />
-    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.10" />
-    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.9" />
-    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.9" />      
+    <PackageReference Include="MonoGame.Tool.Basisu" Version="2.0.2.1" />
+    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.7" />
+    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.11" />
+    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.10" />
+    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.10" />    
   </ItemGroup>
 </Project>

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
@@ -12,14 +12,16 @@
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">
     <ItemGroup>
-      <AndroidAsset Include="$(ProjectDir)$(OutputPath)Content\**\*"
+      <GeneratedAsset Include="$(ProjectDir)$(OutputPath)Content\**\*" />
+
+      <AndroidAsset Include="@(GeneratedAsset)"
         Condition="'$(MonoGamePlatform)' == 'Android'">
-        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Link>Content\%(GeneratedAsset.RecursiveDir)%(GeneratedAsset.Filename)%(GeneratedAsset.Extension)</Link>
       </AndroidAsset>
 
-      <BundledResource Include="$(ProjectDir)$(OutputPath)Content\**\*"
+      <BundledResource Include="@(GeneratedAsset)"
         Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
-        <Link>Content\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Link>Content\%(GeneratedAsset.RecursiveDir)%(GeneratedAsset.Filename)%(GeneratedAsset.Extension)</Link>
       </BundledResource>
     </ItemGroup>
   </Target>

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/MGNamespace.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.5-preview.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.2" />
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
     <PackageReference Include="MonoGame.Library.MojoShader" Version="1.0.0.5" />
-    <PackageReference Include="MonoGame.Tool.Basisu" Version="1.60.0.3" />
-    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.5" />
-    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.10" />
-    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.9" />
-    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.9" />      
+    <PackageReference Include="MonoGame.Tool.Basisu" Version="2.0.2.1" />
+    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.7" />
+    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.11" />
+    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.10" />
+    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

Preview.5 introduced new mandatory NuGet dependencies updates, so all dependencies update to latest

Additionally, there was an issue with the iOS / Android asset post-processing, which did not take into account the relative path of the content builder project (which did not affect the original MGCB implementation as it was not a console app)

Needs testing again post merge