### PR TITLE
Fix Content Builder template restore and quoted paths

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -3,11 +3,13 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentOutputArgument>$([System.String]::Copy('$(ContentOutput)').Replace('\', '/'))</ContentOutputArgument>
+      <ContentTempArgument>$([System.String]::Copy('$(ContentTemp)').Replace('\', '/'))</ContentTempArgument>
+      <ContentArgs>build -p $(MonoGamePlatform) -s &quot;___SafeGameName___.Content/Assets&quot; -o &quot;$(ContentOutputArgument)&quot; -i &quot;$(ContentTempArgument)&quot;</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Restore;Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Exec Command="&quot;$(ContentCommand)&quot; $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -3,11 +3,13 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentOutputArgument>$([System.String]::Copy('$(ContentOutput)').Replace('\', '/'))</ContentOutputArgument>
+      <ContentTempArgument>$([System.String]::Copy('$(ContentTemp)').Replace('\', '/'))</ContentTempArgument>
+      <ContentArgs>build -p $(MonoGamePlatform) -s &quot;___SafeGameName___.Content/Assets&quot; -o &quot;$(ContentOutputArgument)&quot; -i &quot;$(ContentTempArgument)&quot;</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Restore;Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Exec Command="&quot;$(ContentCommand)&quot; $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
@@ -3,11 +3,13 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentOutputArgument>$([System.String]::Copy('$(ContentOutput)').Replace('\', '/'))</ContentOutputArgument>
+      <ContentTempArgument>$([System.String]::Copy('$(ContentTemp)').Replace('\', '/'))</ContentTempArgument>
+      <ContentArgs>build -p $(MonoGamePlatform) -s &quot;___SafeGameName___.Content/Assets&quot; -o &quot;$(ContentOutputArgument)&quot; -i &quot;$(ContentTempArgument)&quot;</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Restore;Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Exec Command="&quot;$(ContentCommand)&quot; $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">


### PR DESCRIPTION
Fixes MonoGame/MonoGame#9141.
Fixes MonoGame/MonoGame#9144.

The Content Builder templates generate `BuildContent.targets` files that run the generated content builder before game compilation. The current targets have two first-run/path problems:

- The content project is built without an explicit restore, so a fresh clone or cleaned `bin`/`obj` can fail before `project.assets.json` exists.
- The generated `Exec` command does not quote the content-builder executable or path arguments, so solutions under directories containing spaces can split the executable/output/intermediate paths.

This updates all three Content Builder template targets to:

- run `Restore;Build` for the content project before executing it;
- quote the generated content-builder executable;
- quote source/output/intermediate arguments;
- normalize output/intermediate argument paths to forward slashes before quoting so Windows paths ending in `\` do not escape the closing quote in argv parsing.

Validation:

- Parsed all three changed `.targets` files as XML.
- `git diff --check` passed.
- `dotnet pack CSharp\MonoGame.Templates.CSharp.csproj -p:Configuration=Release /p:Version=3.8.4` passed.
- Installed the generated nupkg into a clean isolated custom template hive.
- Generated `mgblankmgcbstartkit` into `C:\tmp\MonoGame Preview Smoke\SpaceGame2`, a path containing spaces.
- Confirmed generated `BuildContent.targets` contains `Targets="Restore;Build"`, quoted executable/source/output/intermediate args, and forward-slash output/intermediate args.
- `DOTNET_ROLL_FORWARD=Major dotnet build "C:\tmp\MonoGame Preview Smoke\SpaceGame2\SpaceGame2.DesktopGL\SpaceGame2.DesktopGL.csproj" -v:minimal` passed.

Note: without `DOTNET_ROLL_FORWARD=Major`, this local machine builds the generated content project but cannot run it because only .NET 10 runtimes are installed and the template targets `net9.0`. That environment-only run reached the correctly quoted command line and failed with the expected missing `Microsoft.NETCore.App 9.0.0` host error, not with a path/restore failure.