### PR TITLE
Log Content Builder command before execution

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -7,6 +7,7 @@
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Message Importance="High" Text="$(ContentCommand) $(ContentArgs)" />
     <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -7,6 +7,7 @@
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Message Importance="High" Text="$(ContentCommand) $(ContentArgs)" />
     <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
@@ -7,6 +7,7 @@
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <Message Importance="High" Text="$(ContentCommand) $(ContentArgs)" />
     <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"


### PR DESCRIPTION
Fixes #39.

The Content Builder templates currently print `Content Builder started`, but the generated MSBuild target does not show the command line that is about to be executed. This adds a high-importance MSBuild `Message` immediately before the `Exec` task in all three generated `BuildContent.targets` files, using the same `$(ContentCommand) $(ContentArgs)` expression that the `Exec` task runs.

Validation:

- Parsed all three changed `.targets` files as XML.
- `git diff --check` passed.
- `dotnet pack CSharp\MonoGame.Templates.CSharp.csproj -p:Configuration=Release /p:Version=3.8.5` passed.
- Installed the generated nupkg into an isolated custom template hive.
- Generated `mgblankmgcbstartkit` into `C:\tmp\mgtemplates-39-smoke\CommandMessageGame`.
- Confirmed generated `CommandMessageGame.Content\BuildContent.targets` contains the new `Message` task.
- Restored the generated content project, then built `CommandMessageGame.DesktopGL.csproj` with `DOTNET_ROLL_FORWARD=Major`; build succeeded and printed the generated Content Builder command line before `[I] Starting Content Builder`.

AI-assisted contribution: implementation and verification were performed with OpenAI Codex under my direction.