### PR TITLE
Update content build target for new namespace

### DIFF
--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
@@ -3,10 +3,10 @@
     <PropertyGroup>
       <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
       <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
-      <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
+      <ContentArgs>build -p $(MonoGamePlatform) -s MGNamespace/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\MGNamespace</ContentCommand>
     </PropertyGroup>
-    <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)MGNamespace.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
     <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/Builder/Builder.cs
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/Builder/Builder.cs
@@ -42,16 +42,16 @@ public class Builder : ContentBuilder
         /* Examples
 
         // Import all content in the Assets folder using the default importer for their file type.
-        content.Include<WildcardRule>("*");
+        contentCollection.Include<WildcardRule>("*");
 
         // Only copy content from the assets folder rather than build it with the pipeline.
-        content.IncludeCopy<WildcardRule>("*.json");
+        contentCollection.IncludeCopy<WildcardRule>("*.json");
 
         // Exclude assets that match the pattern., only required overriding a default import behaviour.
-        content.Exclude<WildcardRule>("Font/*.txt");
+        contentCollection.Exclude<WildcardRule>("Font/*.txt");
 
         // Include a specific asset with processor parameters.
-        content.Include("Models/character.glb", new FbxImporter(),
+        contentCollection.Include("Models/character.glb", new FbxImporter(),
             new MeshAnimatedModelProcessor()
             {
                 Scale = 100.0f

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/MGNamespace.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.5-preview.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
-    <PackageReference Include="MonoGame.Library.MojoShader" Version="1.0.0.5" />
-    <PackageReference Include="MonoGame.Tool.Basisu" Version="2.0.2.1" />
-    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.7" />
-    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.11" />
-    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.10" />
-    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.10" />
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.*" />
+    <PackageReference Include="MonoGame.Library.MojoShader" Version="1.0.0.*" />
+    <PackageReference Include="MonoGame.Tool.Basisu" Version="2.0.2.*" />
+    <PackageReference Include="MonoGame.Tool.Crunch" Version="1.0.4.*" />
+    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.*" />
+    <PackageReference Include="MonoGame.Tool.FFmpeg" Version="7.0.0.*" />
+    <PackageReference Include="MonoGame.Tool.FFprobe" Version="7.0.0.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The Content Builder Template does not have a __SafeGameName__ template variable. So when creating this the project is just broken. 

I think we should be using  `MGNamespace` instead