### PR TITLE
Fix DesktopVK template to use correct platform in content file

### DIFF
--- a/CSharp/content/MonoGame.Application.DesktopVK.CSharp/Content/Content.mgcb
+++ b/CSharp/content/MonoGame.Application.DesktopVK.CSharp/Content/Content.mgcb
@@ -3,7 +3,7 @@
 
 /outputDir:bin/$(Platform)
 /intermediateDir:obj/$(Platform)
-/platform:DesktopGL
+/platform:DesktopVK
 /config:
 /profile:Reach
 /compress:False


### PR DESCRIPTION
Fixes #54 by replacing the `DesktopGL` platform with `DesktopVK` in the content file template.
