### PR TITLE
Patch MGLib

### DIFF
--- a/CSharp/content/MonoGame.Library.CSharp/MGNamespace.csproj
+++ b/CSharp/content/MonoGame.Library.CSharp/MGNamespace.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
+    <PackageReference Include="MonoGame.Framework.Native" Version="3.8.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
# Summary

Update the MGLib template to use MonoGame.Native as the package dependency shim

Fixes: #22