### PR TITLE
Add Support for spaces in paths

### DIFF
--- a/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -1,13 +1,13 @@
 <Project>
   <Target Name="BuildContent" BeforeTargets="BeforeCompile">
     <PropertyGroup>
-      <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
-      <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentOutput>$([System.IO.Path]::TrimEndingDirectorySeparator('$(ProjectDir)$(OutputPath)'))</ContentOutput>
+      <ContentTemp>$([System.IO.Path]::TrimEndingDirectorySeparator('$(ProjectDir)$(IntermediateOutputPath)'))</ContentTemp>
+      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o &quot;$(ContentOutput)&quot; -i &quot;$(ContentTemp)&quot;</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
+    <Exec Command="&quot;$(ContentCommand)&quot; $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">

--- a/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
+++ b/CSharp/content/MonoGame.Blank.2D.StartKit.CB.CSharp/___SafeGameName___.Content/BuildContent.targets
@@ -1,13 +1,13 @@
 <Project>
   <Target Name="BuildContent" BeforeTargets="BeforeCompile">
     <PropertyGroup>
-      <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
-      <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentOutput>$([System.IO.Path]::TrimEndingDirectorySeparator('$(ProjectDir)$(OutputPath)'))</ContentOutput>
+      <ContentTemp>$([System.IO.Path]::TrimEndingDirectorySeparator('$(ProjectDir)$(IntermediateOutputPath)'))</ContentTemp>
+      <ContentArgs>build -p $(MonoGamePlatform) -s ___SafeGameName___.Content/Assets -o &quot;$(ContentOutput)&quot; -i &quot;$(ContentTemp)&quot;</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\___SafeGameName___.Content</ContentCommand>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileDirectory)___SafeGameName___.Content.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
+    <Exec Command="&quot;$(ContentCommand)&quot; $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">

--- a/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
+++ b/CSharp/content/MonoGame.ContentBuilder.CSharp/BuildContent.targets
@@ -1,13 +1,13 @@
 <Project>
   <Target Name="BuildContent" BeforeTargets="BeforeCompile">
     <PropertyGroup>
-      <ContentOutput>$(ProjectDir)$(OutputPath)</ContentOutput>
-      <ContentTemp>$(ProjectDir)$(IntermediateOutputPath)</ContentTemp>
-      <ContentArgs>build -p $(MonoGamePlatform) -s MGNamespace/Assets -o $(ContentOutput) -i $(ContentTemp)</ContentArgs>
+      <ContentOutput>$([System.IO.Path]::TrimEndingDirectorySeparator('$(ProjectDir)$(OutputPath)'))</ContentOutput>
+      <ContentTemp>$([System.IO.Path]::TrimEndingDirectorySeparator('$(ProjectDir)$(IntermediateOutputPath)'))</ContentTemp>
+      <ContentArgs>build -p $(MonoGamePlatform) -s MGNamespace/Assets -o &quot;$(ContentOutput)&quot; -i &quot;$(ContentTemp)&quot;</ContentArgs>
       <ContentCommand>$(MSBuildThisFileDirectory)bin\Debug\MGNamespace</ContentCommand>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileDirectory)MGNamespace.csproj" Targets="Build" RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers" />
-    <Exec Command="$(ContentCommand) $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
+    <Exec Command="&quot;$(ContentCommand)&quot; $(ContentArgs)" WorkingDirectory="$(MSBuildThisFileDirectory)..\" CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
    </Target>
   <Target Name="AddGeneratedContentAssets"
     AfterTargets="BuildContent">


### PR DESCRIPTION
Fixes https://github.com/MonoGame/MonoGame/issues/9141

add support for quoting paths.

The TrimEnd calls are required to prevent an additional quote, because the end `\` combines with a `"` to produce an extra quote, e.g `\"` 